### PR TITLE
Fix Scout Fly (Overlooking Green Eco Vents) access check

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -187,7 +187,7 @@
                     },
 					{
                         "name": "Scout Fly (Overlooking Green Eco Vents)",
-						"access_rules": ["log_moves,$flybox","DoubleJump,$flybox","Crouch,CrouchJump,$flybox","$no_rando"],
+						"access_rules": ["$log_moves,$flybox","DoubleJump,$flybox","Crouch,CrouchJump,$flybox","$no_rando"],
                         "item_count": 1
                     },
 					{


### PR DESCRIPTION
I just had a run where "Scout Fly (Overlooking Green Eco Vents)" was shown as red even though I could punch up the logs and free the scout fly. I think this PR fixes the problems since all other function calls have a `$` in front of them except this one instance of `log_moves`. I haven't tested it though (I don't know how to), and haven't understood all of your code - but I assume you can easily determine if this actually fixes the issue or not.

Thank you for your amazing project, the tracker helped a ton with my runs so far :)